### PR TITLE
스트리머 닉네임 표시 구현

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,8 @@
     "activeTab",
     "cookies",
     "declarativeNetRequestWithHostAccess",
-    "storage"
+    "storage",
+    "scripting"
   ],
   "host_permissions": [
     "*://*.naver.com/*",

--- a/popup.js
+++ b/popup.js
@@ -13,13 +13,52 @@
   const parsedUrl = new URL(url);
   const parts = parsedUrl.pathname.split("/");
 
+  const getMetadata = async ({ nameQueries }) => {
+    let scriptInjectionResults;
+    try {
+      scriptInjectionResults = await chrome.scripting.executeScript({
+        target: { tabId: activeTab[0].id },
+        func: function (nameQueries) {
+          let streamerName = null;
+          try {
+            for (const nameQuery of nameQueries) {
+              const nameElement = document.querySelector(nameQuery);
+              if (nameElement != null) {
+                streamerName = nameElement.innerText.trim();
+                // SOOP 모바일 레이아웃은 닉네임만 담겨져 있는 요소가 없음
+                if (streamerName.includes("\n")) {
+                  streamerName = streamerName.split("\n")[0];
+                }
+                break;
+              }
+            }
+          } catch(e) {
+            console.error(`Failed to get streamer name: ${e}`);
+          } finally {
+            return {
+              name: streamerName,
+            }
+          }
+        },
+        args: [nameQueries],
+      });
+      return scriptInjectionResults[0].result;
+    } catch (e) {
+      console.error(`Script execution failed: ${e}`);
+    }
+  }
+
   let current;
+  let currentMetadata;
   switch (parsedUrl.hostname) {
     case "chzzk.naver.com":
     case "m.chzzk.naver.com": {
       const id = parts[1] === "live" ? parts[2] : parts[1];
       if (/^[0-9a-f]{32}$/i.test(id)) {
         current = id;
+        currentMetadata = await getMetadata({
+          nameQueries: ["div[class^=video_information_name__] span[class^=name_text__]"]
+        });
       }
       break;
     }
@@ -27,12 +66,18 @@
     case "m.twitch.tv":
       if (/^[a-z0-9_]{4,25}$/i.test(parts[1])) {
         current = `t:${parts[1]}`;
+        currentMetadata = await getMetadata({
+          nameQueries: ["#live-channel-stream-information a h1", "#channel-live-overlay .tw-title"]
+        });
       }
       break;
     case "ch.sooplive.co.kr":
     case "play.sooplive.co.kr":
       if (/^[a-z0-9]{3,12}$/i.test(parts[1])) {
         current = parts[1];
+        currentMetadata = await getMetadata({
+          nameQueries: ["#infoNickName", ".txt_bj"]
+        });
       }
       break;
     case "m.sooplive.co.kr":
@@ -42,6 +87,9 @@
         /^[a-z0-9]{3,12}$/i.test(parts[3])
       ) {
         current = parts[3];
+        currentMetadata = await getMetadata({
+          nameQueries: ["#infoNickName", ".txt_bj"]
+        });
       }
       break;
     case "www.youtube.com":
@@ -60,20 +108,28 @@
           current = `y:${id}`;
         }
       }
+
+      if (current != null) {
+        currentMetadata = await getMetadata({
+          nameQueries: ["ytd-channel-name", "ytm-slim-owner-renderer .slim-owner-channel-name"]
+        });
+      }
       break;
   }
 
-  let { streams } = await chrome.storage.local.get({ streams: [] });
+  let { streams, streamMetadata: rawStreamMetadata } = await chrome.storage.local.get({ streams: [], streamMetadata: [] });
   let streamsSet = new Set(streams);
+  let streamMetadata = new Map(rawStreamMetadata);
   if (current) {
     streamsSet.add(current);
-    await chrome.storage.local.set({ streams: [...streamsSet] });
+    streamMetadata.set(current, currentMetadata);
+    await chrome.storage.local.set({ streams: [...streamsSet], streamMetadata: [...streamMetadata.entries()] });
   }
 
   const list = document.getElementById("streams");
-  for (const s of streamsSet) {
+  for (const stream of streamsSet) {
     const item = document.createElement("div");
-    item.dataset.id = s;
+    item.dataset.id = stream;
     list.appendChild(item);
 
     const move = document.createElement("button");
@@ -82,13 +138,14 @@
     item.appendChild(move);
 
     const span = document.createElement("span");
-    span.textContent = s;
+    const streamName = streamMetadata.get(stream)?.name;
+    span.textContent = streamName != null ? `${streamName} (${stream})` : stream;
     item.appendChild(span);
 
     const remove = document.createElement("button");
     remove.textContent = "X";
     remove.addEventListener("click", async () => {
-      streamsSet.delete(s);
+      streamsSet.delete(stream);
       await chrome.storage.local.set({ streams: [...streamsSet] });
       item.remove();
     });


### PR DESCRIPTION
안녕하세요 😄 Mul.Live를 잘 쓰고 있는 사용자입니다. 우선 좋은 프로그램 구현해주셔서 감사합니다.
최근 업데이트로 사이트 내부에서는 id가 이름 표시로 바뀐지 조금 됐지만, 확장 프로그램 쪽에서는 id로 표시되어 사용이 힘든 것 같아 최대한 기존 구현 흐름을 따라가는 방식으로 구현해보았습니다.

## 변경 사항
- 필요한 권한에 `scripting`을 추가했습니다.
- `async getMetadata({ nameQueries })` 함수를 작성했습니다.
  - 이 함수는 `chrome.scripts.executeScript()` 를 사용하여 `document.querySelector`를 실행하고, 결과로 이름을 담은 객체를 반환하는 함수입니다.
  - nameQueries를 배열로 받는 이유는 같은 사이트 주소를 가지고 있어도 사용자 환경(모바일/데스크탑)에 따라 마크업 구조가 완전히 다른 경우가 있었기 때문입니다. 배열로 들어온 selector를 순차적으로 실행해서 결과가 있으면 중단하고 다음으로 넘어가는 방식으로 구현했습니다.
  - 기존 버전과의 호환성을 유지하기 위해서 메타데이터가 존재하지 않더라도 기존 동작대로 id만 표시하도록 구현했습니다.
- switch-case 내부에 current를 대입하는 모든 줄에 `currentMetadata`를 대입하는 코드를 추가했습니다.
- 로컬스토리지에 저장되는 새 항목을 추가했습니다: `streamMetadata`

## 리뷰 요청사항
- 새로운 권한(scripting) 도입이 적절한지 체크 부탁드립니다. 새로운 권한을 도입하는게 얼마나 부담인지 잘 몰라 최대한 자제하려고 했는데, 기존 정적 인젝션 방식(예: 치지직에선 chzzk.js 스크립트 실행) 코드가 MutationObserver를 다는 등 채팅 기능 지원에 집중하고 있는 것 같아 기존 코드에 메시지 통신 코드를 추가하는 대신 새로운 권한을 도입하는 방식으로 해결했습니다.
- 이름을 모두 사이트에서 파싱해오는 방식이 적절한지 리뷰 부탁드립니다. 사이트쪽 소스코드를 보니 치지직쪽은 api 호출로 이름을 갖고오시는 걸로 확인했습니다. 하지만 이번 PR에서는 type같은 메타데이터를 최대한 추가하지 않으려고 일단 보류했는데, api 호출이 마음에 드신다면 그쪽으로 변경해보겠습니다.

## 스크린샷
![스크린샷 2024-12-26 191841](https://github.com/user-attachments/assets/e720288e-ef76-4364-bd66-beb6caa53ac8)
위에서부터 숲, 유튜브, 치지직, 트위치 채널을 테스트한 결과입니다.
